### PR TITLE
update code base so that it works with fo-dicom 4.0.2  (issue #33)

### DIFF
--- a/DICOMcloud.DataAccess.Database/DICOMcloud.DataAccess.Database.csproj
+++ b/DICOMcloud.DataAccess.Database/DICOMcloud.DataAccess.Database.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Dicom.Core, Version=3.0.2.0, Culture=neutral, PublicKeyToken=3a13f649e28eb09a, processorArchitecture=MSIL">
-      <HintPath>..\packages\fo-dicom.Desktop.3.0.2\lib\net452\Dicom.Core.dll</HintPath>
+    <Reference Include="Dicom.Core, Version=4.0.2.0, Culture=neutral, PublicKeyToken=3a13f649e28eb09a, processorArchitecture=MSIL">
+      <HintPath>..\packages\fo-dicom.Desktop.4.0.2\lib\net45\Dicom.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -116,14 +116,14 @@
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets" Condition="Exists('..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets')" />
+  <PropertyGroup>
+    <PostBuildEvent>call "$(ProjectDir)../Resources\Build\copyAssembly.bat" "$(ProjectDir)../dist" "$(ConfigurationName)" $(TargetPath)</PostBuildEvent>
+  </PropertyGroup>
+  <Import Project="..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets" Condition="Exists('..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets'))" />
+    <Error Condition="!Exists('..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets'))" />
   </Target>
-  <PropertyGroup>
-    <PostBuildEvent>call "$(ProjectDir)../Resources\Build\copyAssembly.bat" "$(ProjectDir)../dist" "$(ConfigurationName)" $(TargetPath)</PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/DICOMcloud.DataAccess.Database/ObjectArchieveDataAccess.cs
+++ b/DICOMcloud.DataAccess.Database/ObjectArchieveDataAccess.cs
@@ -348,7 +348,7 @@ namespace DICOMcloud.DataAccess
 
                 foreach (var studyDs in studies)
                 {
-                    var studyUid = studyDs.Get (DicomTag.StudyInstanceUID, "");
+                    string studyUid = studyDs.GetSingleValueOrDefault (DicomTag.StudyInstanceUID, "");
                     
                     if (studyKeyValuePairs.ContainsKey (studyUid))
                     { 
@@ -371,7 +371,7 @@ namespace DICOMcloud.DataAccess
 
                 foreach (var seriesDs in series)
                 {
-                    var seriesUid = seriesDs.Get (DicomTag.SeriesInstanceUID, "");
+                    var seriesUid = seriesDs.GetSingleValueOrDefault (DicomTag.SeriesInstanceUID, "");
                     
                     if ( seriesKeyValuePairs.ContainsKey (seriesUid))
                     { 
@@ -406,9 +406,9 @@ namespace DICOMcloud.DataAccess
 
             foreach (var seriesDs in series)
             {
-                var studyKey  = seriesDs.Get (DicomTag.StudyInstanceUID, "");
-                var seriesKey = seriesDs.Get (DicomTag.SeriesInstanceUID, "");
-                var modality  = seriesDs.Get (DicomTag.Modality, "");
+                var studyKey  = seriesDs.GetSingleValueOrDefault (DicomTag.StudyInstanceUID, "");
+                var seriesKey = seriesDs.GetSingleValueOrDefault (DicomTag.SeriesInstanceUID, "");
+                var modality  = seriesDs.GetSingleValueOrDefault (DicomTag.Modality, "");
                 StudyAdditionalParams studyParams = null;
 
 
@@ -438,7 +438,7 @@ namespace DICOMcloud.DataAccess
 
             foreach (var instanceDs in instances)
             {
-                var studyKey  = instanceDs.Get (DicomTag.StudyInstanceUID, "");
+                var studyKey  = instanceDs.GetSingleValueOrDefault (DicomTag.StudyInstanceUID, "");
                 StudyAdditionalParams studyParams = null;
 
 
@@ -463,7 +463,7 @@ namespace DICOMcloud.DataAccess
 
             foreach (var instanceDs in instances)
             {
-                var seriesKey = instanceDs.Get(DicomTag.SeriesInstanceUID, "");
+                var seriesKey = instanceDs.GetSingleValueOrDefault(DicomTag.SeriesInstanceUID, "");
                 SeriesAdditionalParams seriesParams = null;
 
 

--- a/DICOMcloud.DataAccess.Database/QueryResponseBuilder/QueryResponseBuilder.cs
+++ b/DICOMcloud.DataAccess.Database/QueryResponseBuilder/QueryResponseBuilder.cs
@@ -111,7 +111,7 @@ namespace DICOMcloud.DataAccess.Database
                     { 
                         if ( column.Table.IsSequence )
                         { 
-                            DicomSequence sq = (DicomSequence) CurrentData.ForeignDs.Get<DicomSequence> (CurrentData.ForeignTagValue) ;
+                            DicomSequence sq = (DicomSequence) CurrentData.ForeignDs.GetSequence (CurrentData.ForeignTagValue) ;
                             DicomDataset item = new DicomDataset ( ) ;
                             
                             sq.Items.Add ( item ) ;

--- a/DICOMcloud.DataAccess.Database/packages.config
+++ b/DICOMcloud.DataAccess.Database/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="fo-dicom" version="3.0.2" targetFramework="net452" />
-  <package id="fo-dicom.Desktop" version="3.0.2" targetFramework="net452" />
+  <package id="fo-dicom" version="4.0.2" targetFramework="net452" />
+  <package id="fo-dicom.Desktop" version="4.0.2" targetFramework="net452" />
 </packages>

--- a/DICOMcloud.Wado.WebApi/DICOMcloud.Wado.WebApi.csproj
+++ b/DICOMcloud.Wado.WebApi/DICOMcloud.Wado.WebApi.csproj
@@ -61,8 +61,8 @@
       <HintPath>..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Dicom.Core, Version=3.0.2.0, Culture=neutral, PublicKeyToken=3a13f649e28eb09a, processorArchitecture=MSIL">
-      <HintPath>..\packages\fo-dicom.Desktop.3.0.2\lib\net452\Dicom.Core.dll</HintPath>
+    <Reference Include="Dicom.Core, Version=4.0.2.0, Culture=neutral, PublicKeyToken=3a13f649e28eb09a, processorArchitecture=MSIL">
+      <HintPath>..\packages\fo-dicom.Desktop.4.0.2\lib\net45\Dicom.Core.dll</HintPath>
     </Reference>
     <Reference Include="Dicom.Native">
       <HintPath>..\packages\fo-dicom.Desktop.3.0.2\build\net452\Dicom.Native.dll</HintPath>
@@ -460,12 +460,12 @@
     <PostBuildEvent>xcopy "$(ProjectDir)../Resources\Database\DICOMcloud.mdf" "$(ProjectDir)App_Data\DB\*" /d /y
 xcopy "$(ProjectDir)../Resources\Database\DICOMcloud.ldf" "$(ProjectDir)App_Data\DB\*" /d /y</PostBuildEvent>
   </PropertyGroup>
-  <Import Project="..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets" Condition="Exists('..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets')" />
+  <Import Project="..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets" Condition="Exists('..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets'))" />
+    <Error Condition="!Exists('..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets'))" />
   </Target>
   <!--<Import Project="..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.9\tools\webjobs.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Web.WebJobs.Publish.1.0.9\tools\webjobs.targets')" />-->
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/DICOMcloud.Wado.WebApi/packages.config
+++ b/DICOMcloud.Wado.WebApi/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net45" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
-  <package id="fo-dicom.Desktop" version="3.0.2" targetFramework="net452" />
+  <package id="fo-dicom.Desktop" version="4.0.2" targetFramework="net452" />
   <package id="log4net" version="2.0.5" targetFramework="net45" />
   <package id="Microsoft.ApplicationInsights" version="2.8.1" targetFramework="net452" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net452" />

--- a/DICOMcloud.Wado/DICOMcloud.Wado.csproj
+++ b/DICOMcloud.Wado/DICOMcloud.Wado.csproj
@@ -49,8 +49,8 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Dicom.Core, Version=3.0.2.0, Culture=neutral, PublicKeyToken=3a13f649e28eb09a, processorArchitecture=MSIL">
-      <HintPath>..\packages\fo-dicom.Desktop.3.0.2\lib\net452\Dicom.Core.dll</HintPath>
+    <Reference Include="Dicom.Core, Version=4.0.2.0, Culture=neutral, PublicKeyToken=3a13f649e28eb09a, processorArchitecture=MSIL">
+      <HintPath>..\packages\fo-dicom.Desktop.4.0.2\lib\net45\Dicom.Core.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -166,12 +166,12 @@
   <PropertyGroup>
     <PostBuildEvent>call "$(ProjectDir)../Resources\Build\copyAssembly.bat" "$(ProjectDir)../dist" "$(ConfigurationName)" $(TargetPath)</PostBuildEvent>
   </PropertyGroup>
-  <Import Project="..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets" Condition="Exists('..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets')" />
+  <Import Project="..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets" Condition="Exists('..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets'))" />
+    <Error Condition="!Exists('..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/DICOMcloud.Wado/Services/OhifService.cs
+++ b/DICOMcloud.Wado/Services/OhifService.cs
@@ -81,9 +81,9 @@ namespace DICOMcloud.Wado
 
             foreach (var instance in instances)
             {
-                var currentStudyUid = instance.Get<string>(DicomTag.StudyInstanceUID);
-                var currentSeriesUid = instance.Get<string>(DicomTag.SeriesInstanceUID);
-                var currentInstanceUid = instance.Get<string>(DicomTag.SOPInstanceUID);
+                var currentStudyUid = instance.GetSingleValue<string>(DicomTag.StudyInstanceUID);
+                var currentSeriesUid = instance.GetSingleValue<string>(DicomTag.SeriesInstanceUID);
+                var currentInstanceUid = instance.GetSingleValue<string>(DicomTag.SOPInstanceUID);
                 OHIFInstance ohifInstance = new OHIFInstance() { SopInstanceUid = currentInstanceUid };
                 OHIFStudy ohifStudy;
                 OHIFSeries ohifSeries;
@@ -93,7 +93,7 @@ namespace DICOMcloud.Wado
                 {
                     ohifStudy = new OHIFStudy() { StudyInstanceUid = currentStudyUid };
 
-                    ohifStudy.PatientName = instance.Get<string>(DicomTag.PatientName, "");
+                    ohifStudy.PatientName = instance.GetSingleValueOrDefault<string>(DicomTag.PatientName, "");
 
                     result.Studies.Add(ohifStudy);
 
@@ -104,7 +104,7 @@ namespace DICOMcloud.Wado
                 {
                     ohifSeries = new OHIFSeries() { SeriesInstanceUid = currentSeriesUid };
 
-                    ohifSeries.SeriesDescription = instance.Get<string>(DicomTag.SeriesDescription, "");
+                    ohifSeries.SeriesDescription = instance.GetSingleValueOrDefault<string>(DicomTag.SeriesDescription, "");
 
                     ohifStudy.SeriesList.Add(ohifSeries);
 
@@ -113,7 +113,7 @@ namespace DICOMcloud.Wado
 
                 ohifInstance.Rows = 1;
                 ohifInstance.Url = CreateOHIFUrl (instance, studyId);
-                ohifInstance.NumberOfFrames = instance.Get<int?>(DicomTag.NumberOfFrames, null);
+                ohifInstance.NumberOfFrames = instance.GetSingleValueOrDefault<int?>(DicomTag.NumberOfFrames, null);
 
                 ohifSeries.Instances.Add(ohifInstance);
             }

--- a/DICOMcloud.Wado/Services/QidoRsService.cs
+++ b/DICOMcloud.Wado/Services/QidoRsService.cs
@@ -284,8 +284,8 @@ namespace DICOMcloud.Wado
             foreach ( var result in results ) 
             {
                 var queryDs = DefaultDicomQueryElements.GetDefaultInstanceQuery();
-                string studyUid  = result.Get<string> ( DicomTag.StudyInstanceUID, "" ) ;
-                string seriesUid = result.Get<string> ( DicomTag.SeriesInstanceUID, "" ) ;
+                string studyUid  = result.GetSingleValueOrDefault<string> ( DicomTag.StudyInstanceUID, "" ) ;
+                string seriesUid = result.GetSingleValueOrDefault<string> ( DicomTag.SeriesInstanceUID, "" ) ;
                 var queryOptions = CreateNewQueryOptions ( ) ;
             
                 queryDs.AddOrUpdate ( DicomTag.StudyInstanceUID, studyUid );
@@ -298,9 +298,9 @@ namespace DICOMcloud.Wado
 
                 foreach  ( var instance in instances )
                 {
-                    queryStudyUid = instance.Get<string> ( DicomTag.StudyInstanceUID, "" ) ;
-                    querySeriesUid = instance.Get<string> ( DicomTag.SeriesInstanceUID, "" ) ;
-                    queryInstanceUid = instance.Get<string> ( DicomTag.SOPInstanceUID, "" ) ;
+                    queryStudyUid = instance.GetSingleValueOrDefault<string> ( DicomTag.StudyInstanceUID, "" ) ;
+                    querySeriesUid = instance.GetSingleValueOrDefault<string> ( DicomTag.SeriesInstanceUID, "" ) ;
+                    queryInstanceUid = instance.GetSingleValueOrDefault<string> ( DicomTag.SOPInstanceUID, "" ) ;
 
                     break ;
                 }
@@ -353,7 +353,7 @@ namespace DICOMcloud.Wado
             DicomDataset  item ;
             
             dicomRequest.AddOrUpdate ( new DicomSequence ( dicEntry.Tag ) ) ;
-            sequence = dicomRequest.Get<DicomSequence>(dicEntry.Tag);
+            sequence = dicomRequest.GetSingleValue<DicomSequence>(dicEntry.Tag);
 
 
             item = new DicomDataset ( ) ;

--- a/DICOMcloud.Wado/Types/DefaultDicomQueryElements.cs
+++ b/DICOMcloud.Wado/Types/DefaultDicomQueryElements.cs
@@ -67,38 +67,38 @@ namespace DICOMcloud.Wado
 
         private static void FillStudyLevel(fo.DicomDataset studyDs)
         {
-            studyDs.Add<object>(fo.DicomTag.SpecificCharacterSet,null) ;
-            studyDs.Add<object>(fo.DicomTag.StudyDate,null) ;
-            studyDs.Add<object>(fo.DicomTag.StudyTime,null) ;
-            studyDs.Add<object>(fo.DicomTag.StudyDescription,null) ;
-            studyDs.Add<object>(fo.DicomTag.AccessionNumber,null) ;
-            studyDs.Add<object>(fo.DicomTag.InstanceAvailability,null) ;
-            studyDs.Add<object>(fo.DicomTag.ModalitiesInStudy,null) ;
-            studyDs.Add<object>(fo.DicomTag.ReferringPhysicianName,null) ;
-            studyDs.Add<object>(fo.DicomTag.TimezoneOffsetFromUTC,null) ;
-            studyDs.Add<object>(fo.DicomTag.RetrieveURI,null) ;
-            studyDs.Add<object>(fo.DicomTag.PatientName,null) ;
-            studyDs.Add<object>(fo.DicomTag.PatientID,null) ;
-            studyDs.Add<object>(fo.DicomTag.PatientBirthDate,null) ;
-            studyDs.Add<object>(fo.DicomTag.PatientSex,null) ;
-            studyDs.Add<object>(fo.DicomTag.StudyInstanceUID,null) ;
-            studyDs.Add<object>(fo.DicomTag.StudyID,null) ;
-            studyDs.Add<object>(fo.DicomTag.NumberOfStudyRelatedSeries,null) ;
-            studyDs.Add<object>(fo.DicomTag.NumberOfStudyRelatedInstances,null) ;
+            studyDs.Add<object>(fo.DicomTag.SpecificCharacterSet,(object)null) ;
+            studyDs.Add<object>(fo.DicomTag.StudyDate,(object)null) ;
+            studyDs.Add<object>(fo.DicomTag.StudyTime,(object)null) ;
+            studyDs.Add<object>(fo.DicomTag.StudyDescription,(object)null) ;
+            studyDs.Add<object>(fo.DicomTag.AccessionNumber,(object)null) ;
+            studyDs.Add<object>(fo.DicomTag.InstanceAvailability,(object)null) ;
+            studyDs.Add<object>(fo.DicomTag.ModalitiesInStudy,(object)null) ;
+            studyDs.Add<object>(fo.DicomTag.ReferringPhysicianName,(object)null) ;
+            studyDs.Add<object>(fo.DicomTag.TimezoneOffsetFromUTC,(object)null) ;
+            studyDs.Add<object>(fo.DicomTag.RetrieveURI,(object)null) ;
+            studyDs.Add<object>(fo.DicomTag.PatientName,(object)null) ;
+            studyDs.Add<object>(fo.DicomTag.PatientID,(object)null) ;
+            studyDs.Add<object>(fo.DicomTag.PatientBirthDate,(object)null) ;
+            studyDs.Add<object>(fo.DicomTag.PatientSex,(object)null) ;
+            studyDs.Add<object>(fo.DicomTag.StudyInstanceUID,(object)null) ;
+            studyDs.Add<object>(fo.DicomTag.StudyID,(object)null) ;
+            studyDs.Add<object>(fo.DicomTag.NumberOfStudyRelatedSeries,(object)null) ;
+            studyDs.Add<object>(fo.DicomTag.NumberOfStudyRelatedInstances,(object)null) ;
         }
 
         private static void FillSeriesLevel(fo.DicomDataset seriesDs)
         {
-            seriesDs.Add<object>(fo.DicomTag.SpecificCharacterSet,null) ;
-            seriesDs.Add<object>(fo.DicomTag.Modality,null) ;
-            seriesDs.Add<object>(fo.DicomTag.TimezoneOffsetFromUTC,null) ;
-            seriesDs.Add<object>(fo.DicomTag.SeriesDescription,null) ;
-            seriesDs.Add<object>(fo.DicomTag.RetrieveURI,null) ;
-            seriesDs.Add<object>(fo.DicomTag.SeriesInstanceUID,null) ;
-            seriesDs.Add<object>(fo.DicomTag.SeriesNumber,null) ;
-            seriesDs.Add<object>(fo.DicomTag.NumberOfSeriesRelatedInstances,null) ;
-            seriesDs.Add<object>(fo.DicomTag.PerformedProcedureStepStartDate,null) ;
-            seriesDs.Add<object>(fo.DicomTag.PerformedProcedureStepStartTime,null) ;
+            seriesDs.Add<object>(fo.DicomTag.SpecificCharacterSet,(object)null) ;
+            seriesDs.Add<object>(fo.DicomTag.Modality,(object)null) ;
+            seriesDs.Add<object>(fo.DicomTag.TimezoneOffsetFromUTC,(object)null) ;
+            seriesDs.Add<object>(fo.DicomTag.SeriesDescription,(object)null) ;
+            seriesDs.Add<object>(fo.DicomTag.RetrieveURI,(object)null) ;
+            seriesDs.Add<object>(fo.DicomTag.SeriesInstanceUID,(object)null) ;
+            seriesDs.Add<object>(fo.DicomTag.SeriesNumber,(object)null) ;
+            seriesDs.Add<object>(fo.DicomTag.NumberOfSeriesRelatedInstances,(object)null) ;
+            seriesDs.Add<object>(fo.DicomTag.PerformedProcedureStepStartDate,(object)null) ;
+            seriesDs.Add<object>(fo.DicomTag.PerformedProcedureStepStartTime,(object)null) ;
             //seriesDs.Add<object>(fo.DicomTag.RequestAttributesSequence,null) ; //Not supported yet
 
 
@@ -106,15 +106,15 @@ namespace DICOMcloud.Wado
 
         private static void FillInstsanceLevel(fo.DicomDataset instanceDs)
         {
-            instanceDs.Add<object>(fo.DicomTag.SpecificCharacterSet,null) ;
-            instanceDs.Add<object>(fo.DicomTag.SOPClassUID,null) ;
-            instanceDs.Add<object>(fo.DicomTag.SOPInstanceUID,null) ;
-            instanceDs.Add<object>(fo.DicomTag.InstanceNumber,null) ;
+            instanceDs.Add<object>(fo.DicomTag.SpecificCharacterSet,(object)null) ;
+            instanceDs.Add<object>(fo.DicomTag.SOPClassUID,(object)null) ;
+            instanceDs.Add<object>(fo.DicomTag.SOPInstanceUID,(object)null) ;
+            instanceDs.Add<object>(fo.DicomTag.InstanceNumber,(object)null) ;
 
-            instanceDs.Add<object>(fo.DicomTag.Rows, null);
-            instanceDs.Add<object>(fo.DicomTag.Columns, null);
-            instanceDs.Add<object>(fo.DicomTag.BitsAllocated, null);
-            instanceDs.Add<object>(fo.DicomTag.NumberOfFrames, null);
+            instanceDs.Add<object>(fo.DicomTag.Rows, (object)null);
+            instanceDs.Add<object>(fo.DicomTag.Columns, (object)null);
+            instanceDs.Add<object>(fo.DicomTag.BitsAllocated, (object)null);
+            instanceDs.Add<object>(fo.DicomTag.NumberOfFrames, (object)null);
         }
     }
 }

--- a/DICOMcloud.Wado/WadoResponse/WadoStoreResponse.cs
+++ b/DICOMcloud.Wado/WadoResponse/WadoStoreResponse.cs
@@ -57,7 +57,7 @@ namespace DICOMcloud.Wado
         public void AddResult ( DicomDataset ds, Exception ex )
         {
             var referencedInstance = GetReferencedInstsance ( ds ) ;
-            var failedSeq          = (_dataset.Contains (DicomTag.FailedSOPSequence)) ? _dataset.Get<DicomSequence>(DicomTag.FailedSOPSequence) : new DicomSequence ( DicomTag.FailedSOPSequence ) ;
+            var failedSeq          = (_dataset.Contains (DicomTag.FailedSOPSequence)) ? _dataset.GetSingleValue<DicomSequence>(DicomTag.FailedSOPSequence) : new DicomSequence ( DicomTag.FailedSOPSequence ) ;
             var item               = new DicomDataset ( ) ;
 
 
@@ -84,7 +84,7 @@ namespace DICOMcloud.Wado
         public void AddResult ( DicomDataset ds )
         {
             var referencedInstance = GetReferencedInstsance ( ds ) ;
-            var referencedSeq      = (_dataset.Contains(DicomTag.ReferencedSOPSequence)) ? _dataset.Get<DicomSequence>(DicomTag.ReferencedSOPSequence) : new DicomSequence ( DicomTag.ReferencedSOPSequence) ;
+            var referencedSeq      = (_dataset.Contains(DicomTag.ReferencedSOPSequence)) ? _dataset.GetSingleValue<DicomSequence>(DicomTag.ReferencedSOPSequence) : new DicomSequence ( DicomTag.ReferencedSOPSequence) ;
             var item               = new fo.DicomDataset ( ) ;
 
 
@@ -109,8 +109,8 @@ namespace DICOMcloud.Wado
         
         private fo.DicomDataset GetReferencedInstsance ( fo.DicomDataset ds )
         {
-            var classUID = ds.Get<fo.DicomElement> ( fo.DicomTag.SOPClassUID, null ) ;
-            var sopUID   = ds.Get<fo.DicomElement> ( fo.DicomTag.SOPInstanceUID, null ) ;
+            var classUID = ds.GetSingleValueOrDefault<fo.DicomElement> ( fo.DicomTag.SOPClassUID, null ) ;
+            var sopUID   = ds.GetSingleValueOrDefault<fo.DicomElement> ( fo.DicomTag.SOPInstanceUID, null ) ;
             var dataset  = new fo.DicomDataset ( ) ;
 
 

--- a/DICOMcloud.Wado/packages.config
+++ b/DICOMcloud.Wado/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="fo-dicom.Desktop" version="3.0.2" targetFramework="net452" />
+  <package id="fo-dicom.Desktop" version="4.0.2" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.6" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.6" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />

--- a/DICOMcloud/DICOMcloud.csproj
+++ b/DICOMcloud/DICOMcloud.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Dicom.Core, Version=3.0.2.0, Culture=neutral, PublicKeyToken=3a13f649e28eb09a, processorArchitecture=MSIL">
-      <HintPath>..\packages\fo-dicom.Desktop.3.0.2\lib\net452\Dicom.Core.dll</HintPath>
+    <Reference Include="Dicom.Core, Version=4.0.2.0, Culture=neutral, PublicKeyToken=3a13f649e28eb09a, processorArchitecture=MSIL">
+      <HintPath>..\packages\fo-dicom.Desktop.4.0.2\lib\net45\Dicom.Core.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -181,14 +181,14 @@
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets" Condition="Exists('..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets')" />
+  <PropertyGroup>
+    <PostBuildEvent>call "$(ProjectDir)../Resources\Build\copyAssembly.bat" "$(ProjectDir)../dist" "$(ConfigurationName)" $(TargetPath)</PostBuildEvent>
+  </PropertyGroup>
+  <Import Project="..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets" Condition="Exists('..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets'))" />
+    <Error Condition="!Exists('..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets'))" />
   </Target>
-  <PropertyGroup>
-    <PostBuildEvent>call "$(ProjectDir)../Resources\Build\copyAssembly.bat" "$(ProjectDir)../dist" "$(ConfigurationName)" $(TargetPath)</PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/DICOMcloud/DICOMcloud/DicomObjectId/DicomObjectIdFactory.cs
+++ b/DICOMcloud/DICOMcloud/DicomObjectId/DicomObjectIdFactory.cs
@@ -27,9 +27,9 @@ namespace DICOMcloud
         public virtual IObjectId CreateObjectId ( DicomDataset dataset )
         {
             return new ObjectId ( ) {
-                StudyInstanceUID = dataset.Get<string>(DicomTag.StudyInstanceUID, 0, ""),
-                SeriesInstanceUID = dataset.Get<string>(DicomTag.SeriesInstanceUID, 0, ""),
-                SOPInstanceUID = dataset.Get<string>(DicomTag.SOPInstanceUID, 0, "")
+                StudyInstanceUID = dataset.GetValueOrDefault(DicomTag.StudyInstanceUID, 0, ""),
+                SeriesInstanceUID = dataset.GetValueOrDefault(DicomTag.SeriesInstanceUID, 0, ""),
+                SOPInstanceUID = dataset.GetValueOrDefault(DicomTag.SOPInstanceUID, 0, "")
             } ;
         }
     }

--- a/DICOMcloud/DICOMcloud/JsonDicomConverter.cs
+++ b/DICOMcloud/DICOMcloud/JsonDicomConverter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Linq;
+using Dicom.Imaging;
 using Newtonsoft.Json;
 using fo = Dicom;
 
@@ -392,7 +393,8 @@ namespace DICOMcloud
 
                 if ( tag == fo.DicomTag.PixelData && level == 0 )
                 {
-                    dataset.AddOrUpdatePixelData ( vr, data, fo.DicomTransferSyntax.Parse ( TransferSyntaxUID ) ) ;
+                  var pixelData= DicomPixelData.Create(dataset, true);  //2nd parameter is true since we are adding new data here
+                    pixelData.AddFrame(data);
 
                 }
                 else
@@ -424,7 +426,10 @@ namespace DICOMcloud
             
                 if ( tag == fo.DicomTag.PixelData && level == 0 )
                 {
-                    dataset.AddOrUpdatePixelData ( vr, buffer, fo.DicomTransferSyntax.Parse ( TransferSyntaxUID ) ) ;
+                    
+                    var pixelData= DicomPixelData.Create(dataset, true);  //2nd parameter is true since we are adding new data here
+                 
+                    pixelData.AddFrame(buffer);
                 }
                 else
                 {

--- a/DICOMcloud/DICOMcloud/JsonDicomConverter.cs
+++ b/DICOMcloud/DICOMcloud/JsonDicomConverter.cs
@@ -413,7 +413,6 @@ namespace DICOMcloud
             if ( reader.Read ( ) )
             {
                 fo.IO.Buffer.MemoryByteBuffer buffer = null ;
-                byte[] data   = new byte[0] ;
                 string base64 = (string) reader.Value ;
             
                 

--- a/DICOMcloud/DICOMcloud/JsonDicomConverter.cs
+++ b/DICOMcloud/DICOMcloud/JsonDicomConverter.cs
@@ -393,6 +393,7 @@ namespace DICOMcloud
                 if ( tag == fo.DicomTag.PixelData && level == 0 )
                 {
                     dataset.AddOrUpdatePixelData ( vr, data, fo.DicomTransferSyntax.Parse ( TransferSyntaxUID ) ) ;
+
                 }
                 else
                 {

--- a/DICOMcloud/DICOMcloud/XmlDicomConverter.cs
+++ b/DICOMcloud/DICOMcloud/XmlDicomConverter.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
 using System.IO;
+using Dicom.Imaging;
 
 namespace DICOMcloud
 {
@@ -405,7 +406,9 @@ namespace DICOMcloud
                     
                     if ( tag == fo.DicomTag.PixelData && level == 0 ) 
                     {
-                        ds.AddOrUpdatePixelData ( dicomVr, data, TransferSyntax ) ;
+                     
+                        var pixelData= DicomPixelData.Create(ds, true);  //2nd parameter is true since we are adding new data here
+                        pixelData.AddFrame(data);
                     }
                     else
                     {

--- a/DICOMcloud/DICOMcloud/XmlDicomConverter.cs
+++ b/DICOMcloud/DICOMcloud/XmlDicomConverter.cs
@@ -229,7 +229,7 @@ namespace DICOMcloud
                     
                 if ( dicomVr.Equals(fo.DicomVR.AT))
                 {
-                    var    atElement   = ds.Get<fo.DicomElement>    ( element.Tag, null ) ;
+                    var    atElement   = ds.GetSingleValueOrDefault<fo.DicomElement>    ( element.Tag, null ) ;
                     var    tagValue    = atElement.Get<fo.DicomTag> ( ) ;
                     string stringValue = tagValue.ToString          ( "J", null ) ;
 
@@ -237,7 +237,7 @@ namespace DICOMcloud
                 }
                 else
                 {
-                    writer.WriteString ( GetTrimmedString ( ds.Get<string> ( element.Tag, index, string.Empty ) ) ); 
+                    writer.WriteString ( GetTrimmedString ( ds.GetValueOrDefault( element.Tag, index, string.Empty ) ) ); 
                 }
 
                 writer.WriteEndElement ( );

--- a/DICOMcloud/Media/DicomMediaId.cs
+++ b/DICOMcloud/Media/DicomMediaId.cs
@@ -43,9 +43,9 @@ namespace DICOMcloud.Media
         )
         {
             var dicomObject   = new ObjectId ( ) {
-            StudyInstanceUID  = dataset.Get<string> ( fo.DicomTag.StudyInstanceUID, 0, "" ),
-            SeriesInstanceUID = dataset.Get<string> ( fo.DicomTag.SeriesInstanceUID, 0,""), 
-            SOPInstanceUID    = dataset.Get<string> ( fo.DicomTag.SOPInstanceUID, 0, ""),
+            StudyInstanceUID  = dataset.GetValueOrDefault(fo.DicomTag.StudyInstanceUID, 0, "" ),
+            SeriesInstanceUID = dataset.GetValueOrDefault ( fo.DicomTag.SeriesInstanceUID, 0,""), 
+            SOPInstanceUID    = dataset.GetValueOrDefault ( fo.DicomTag.SOPInstanceUID, 0, ""),
             Frame             = frame } ;
             
             Init ( dicomObject, mediaType, transferSyntax ) ;

--- a/DICOMcloud/Media/Writers/JpegMediaWriter.cs
+++ b/DICOMcloud/Media/Writers/JpegMediaWriter.cs
@@ -49,7 +49,7 @@ namespace DICOMcloud.Media
         {
             var frameIndex = frame - 1 ;
             var dicomImage = new DicomImage (dicomObject, frameIndex);
-            var bitmap = dicomImage.RenderImage (frameIndex).AsBitmap();
+            var bitmap = dicomImage.RenderImage (frameIndex).AsSharedBitmap();
             var stream = new MemoryStream ( ) ;
             
             bitmap.Save (stream, System.Drawing.Imaging.ImageFormat.Jpeg );

--- a/DICOMcloud/Pacs/Commands/StoreCommand.cs
+++ b/DICOMcloud/Pacs/Commands/StoreCommand.cs
@@ -18,12 +18,12 @@ namespace DICOMcloud.Pacs.Commands
         {
             RequiredDsElements = new DicomDataset ( ) ;
 
-            RequiredDsElements.Add<object> ( DicomTag.PatientID, null) ;
-            RequiredDsElements.Add<object> ( DicomTag.StudyInstanceUID, null) ;
-            RequiredDsElements.Add<object> ( DicomTag.SeriesInstanceUID, null) ;
-            RequiredDsElements.Add<object> ( DicomTag.Modality, null) ;
-            RequiredDsElements.Add<object> ( DicomTag.SOPClassUID, null) ;
-            RequiredDsElements.Add<object> ( DicomTag.SOPInstanceUID, null) ;
+            RequiredDsElements.Add<object> ( DicomTag.PatientID,(object) null) ;
+            RequiredDsElements.Add<object> ( DicomTag.StudyInstanceUID, (object)null) ;
+            RequiredDsElements.Add<object> ( DicomTag.SeriesInstanceUID, (object)null) ;
+            RequiredDsElements.Add<object> ( DicomTag.Modality, (object)null) ;
+            RequiredDsElements.Add<object> ( DicomTag.SOPClassUID, (object)null) ;
+            RequiredDsElements.Add<object> ( DicomTag.SOPInstanceUID, (object)null) ;
         }
 
         public StoreCommand ( ) : this ( null, null ) 

--- a/DICOMcloud/Pacs/Commands/StoreCommand.cs
+++ b/DICOMcloud/Pacs/Commands/StoreCommand.cs
@@ -18,12 +18,12 @@ namespace DICOMcloud.Pacs.Commands
         {
             RequiredDsElements = new DicomDataset ( ) ;
 
-            RequiredDsElements.Add<object> ( DicomTag.PatientID,(object) null) ;
-            RequiredDsElements.Add<object> ( DicomTag.StudyInstanceUID, (object)null) ;
-            RequiredDsElements.Add<object> ( DicomTag.SeriesInstanceUID, (object)null) ;
-            RequiredDsElements.Add<object> ( DicomTag.Modality, (object)null) ;
-            RequiredDsElements.Add<object> ( DicomTag.SOPClassUID, (object)null) ;
-            RequiredDsElements.Add<object> ( DicomTag.SOPInstanceUID, (object)null) ;
+            RequiredDsElements.Add<string> ( DicomTag.PatientID,(string) null) ;
+            RequiredDsElements.Add<string> ( DicomTag.StudyInstanceUID, (string)null) ;
+            RequiredDsElements.Add<string> ( DicomTag.SeriesInstanceUID, (string)null) ;
+            RequiredDsElements.Add<string> ( DicomTag.Modality, (string)null) ;
+            RequiredDsElements.Add<string> ( DicomTag.SOPClassUID, (string)null) ;
+            RequiredDsElements.Add<string> ( DicomTag.SOPInstanceUID, (string)null) ;
         }
 
         public StoreCommand ( ) : this ( null, null ) 

--- a/DICOMcloud/Pacs/Commands/StoreCommand.cs
+++ b/DICOMcloud/Pacs/Commands/StoreCommand.cs
@@ -100,7 +100,7 @@ namespace DICOMcloud.Pacs.Commands
                     throw new DCloudException ( "Required element is missing. Element: " + element.Tag.DictionaryEntry.Name.ToString ( ) ) ;
                 }
 
-                if ( dataset.Get<string> (element.Tag, null) == null )
+                if ( dataset.GetSingleValueOrDefault<string> (element.Tag, null) == null )
                 {
                     throw new DCloudException ( "Required element has no value. Element: " + element.Tag.DictionaryEntry.Name.ToString ( ) ) ;
                 }

--- a/DICOMcloud/packages.config
+++ b/DICOMcloud/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="fo-dicom.Desktop" version="3.0.2" targetFramework="net452" />
+  <package id="fo-dicom.Desktop" version="4.0.2" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
   <package id="PubSub" version="1.5.0" targetFramework="net452" />
 </packages>

--- a/UnitTests/DICOMcloud.Dicom.UnitTest/ArchieveDataAccessTests.cs
+++ b/UnitTests/DICOMcloud.Dicom.UnitTest/ArchieveDataAccessTests.cs
@@ -91,7 +91,7 @@ namespace DICOMcloud.UnitTest
 
             Assert.IsNotNull ( queryDs);
             Assert.AreEqual  ( queryDs.Count ( ), 1 ) ;
-            Assert.AreEqual  ( ds.Get<string>(DicomTag.SOPInstanceUID), queryDs.First ( ).Get<string>(DicomTag.SOPInstanceUID));
+            Assert.AreEqual  ( ds.GetSingleValue<string>(DicomTag.SOPInstanceUID), queryDs.First ( ).GetSingleValue<string>(DicomTag.SOPInstanceUID));
         }
 
         private void ValidateStudyCount ( int studies ) 

--- a/UnitTests/DICOMcloud.Dicom.UnitTest/DICOMcloud.UnitTest.csproj
+++ b/UnitTests/DICOMcloud.Dicom.UnitTest/DICOMcloud.UnitTest.csproj
@@ -39,8 +39,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Dicom.Core, Version=3.0.2.0, Culture=neutral, PublicKeyToken=3a13f649e28eb09a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\fo-dicom.Desktop.3.0.2\lib\net452\Dicom.Core.dll</HintPath>
+    <Reference Include="Dicom.Core, Version=4.0.2.0, Culture=neutral, PublicKeyToken=3a13f649e28eb09a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\fo-dicom.Desktop.4.0.2\lib\net45\Dicom.Core.dll</HintPath>
     </Reference>
     <Reference Include="Dicom.Native">
       <HintPath>..\..\packages\fo-dicom.Desktop.3.0.2\build\net452\Dicom.Native.dll</HintPath>
@@ -103,17 +103,17 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets" Condition="Exists('..\..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\fo-dicom.Desktop.3.0.2\build\net452\fo-dicom.Desktop.targets'))" />
-  </Target>
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(ProjectDir)../../Resources\Database\DICOMcloud.mdf" "$(TargetDir)*.*" /d /y
 xcopy "$(ProjectDir)../../Resources\Database\DICOMcloud.ldf" "$(TargetDir)*.*" /d /y</PostBuildEvent>
   </PropertyGroup>
+  <Import Project="..\..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets" Condition="Exists('..\..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\fo-dicom.Desktop.4.0.2\build\net45\fo-dicom.Desktop.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/UnitTests/DICOMcloud.Dicom.UnitTest/DicomDatasetConvertersTests.cs
+++ b/UnitTests/DICOMcloud.Dicom.UnitTest/DicomDatasetConvertersTests.cs
@@ -73,7 +73,7 @@ namespace DICOMcloud.UnitTest
             
                 var dsF = new fo.DicomFile ( targetDs ) ;
             
-                dsF.FileMetaInfo.TransferSyntax = fo.DicomTransferSyntax.Parse( targetDs.Get ( fo.DicomTag.TransferSyntaxUID, targetDs.InternalTransferSyntax.ToString ( ) ) ) ;
+                dsF.FileMetaInfo.TransferSyntax = fo.DicomTransferSyntax.Parse( targetDs.GetSingleValueOrDefault ( fo.DicomTag.TransferSyntaxUID, targetDs.InternalTransferSyntax.ToString ( ) ) ) ;
                 
                 dsF.Save ( fullPath + ".gen.dcm" ) ;
 

--- a/UnitTests/DICOMcloud.Dicom.UnitTest/Helpers/DicomHelpers.cs
+++ b/UnitTests/DICOMcloud.Dicom.UnitTest/Helpers/DicomHelpers.cs
@@ -14,15 +14,21 @@ namespace DICOMcloud.UnitTest
     {
         public DicomHelpers ( ) 
         {
-            Study1UID    = "test.study.1" ;
-            Study2UID    = "test.study.2" ;
+            // the new fo-dicom 4.0.0 does not allow letters in UIDs  the standard allows only 0-9 and . separator
+          // leading zeros are also not allowed
+            Study1UID    = "9999.1111.1" ;
+            Study2UID    = "9999.1111.2" ;
             Study3UID    =  Study2UID ;
-            Series1UID   = "test.series.1" ;
-            Series2UID   = "test.series.2" ;
-            Series3UID   = "test.series.3" ;
-            Instance1UID = "test.instance.1" ;
-            Instance2UID = "test.instance.2" ;
-            Instance3UID = "test.instance.3" ;
+            
+            Series1UID   = "1111.1111.1" ;
+            Series2UID   = "1111.1111.2" ;
+            Series3UID   = "1111.1111.3" ;
+            
+            Instance1UID = "2222.1111.1" ;
+            Instance2UID = "2222.1111.2" ;
+            Instance3UID = "2222.1111.3" ;
+
+            SOPClass1UID = "3333.1111.1" ;
         }
         
         public static string GetBaseFolder ( ) 
@@ -138,6 +144,10 @@ namespace DICOMcloud.UnitTest
         {
             get; set;
         }
+        public string SOPClass1UID
+        {
+            get; set;
+        }
 
 
         public fo.DicomDataset GetQueryDataset ( ) 
@@ -183,7 +193,7 @@ namespace DICOMcloud.UnitTest
             ds.Add ( fo.DicomTag.SeriesNumber, 1 );
             ds.Add ( fo.DicomTag.Modality, "XA" );
             ds.Add ( fo.DicomTag.SOPInstanceUID, Instance1UID );
-            ds.Add ( fo.DicomTag.SOPClassUID, "test.instance.class.uid" );
+            ds.Add ( fo.DicomTag.SOPClassUID, SOPClass1UID);
             ds.Add ( fo.DicomTag.InstanceNumber, 1 );
 
             ds.Add(fo.DicomTag.NumberOfFrames, 1);

--- a/UnitTests/DICOMcloud.Dicom.UnitTest/Helpers/DicomHelpers.cs
+++ b/UnitTests/DICOMcloud.Dicom.UnitTest/Helpers/DicomHelpers.cs
@@ -155,24 +155,24 @@ namespace DICOMcloud.UnitTest
             var ds = new fo.DicomDataset ( ) ;
 
 
-            ds.Add<object> ( fo.DicomTag.PatientID,(object) null) ;
-            ds.Add<object>( fo.DicomTag.PatientName, (object)null);
-            ds.Add<object>( fo.DicomTag.StudyInstanceUID, (object)null);
-            ds.Add<object>( fo.DicomTag.StudyID, (object)null);
-            ds.Add<object>(fo.DicomTag.StudyDate, (object)null);
-            ds.Add<object>( fo.DicomTag.AccessionNumber, (object)null);
-            ds.Add<object>(fo.DicomTag.StudyDescription, (object)null);
-            ds.Add<object>( fo.DicomTag.SeriesInstanceUID, (object)null);
-            ds.Add<object>( fo.DicomTag.SeriesNumber, (object)null);
-            ds.Add<object>( fo.DicomTag.Modality, (object)null);
-            ds.Add<object>( fo.DicomTag.SOPInstanceUID, (object)null);
-            ds.Add<object>( fo.DicomTag.SOPClassUID, (object)null);
-            ds.Add<object>( fo.DicomTag.InstanceNumber, (object)null);
+            ds.Add<string> ( fo.DicomTag.PatientID,(string) null) ;
+            ds.Add<string>( fo.DicomTag.PatientName, (string)null);
+            ds.Add<string>( fo.DicomTag.StudyInstanceUID, (string)null);
+            ds.Add<string>( fo.DicomTag.StudyID, (string)null);
+            ds.Add<string>(fo.DicomTag.StudyDate, (string)null);
+            ds.Add<string>( fo.DicomTag.AccessionNumber, (string)null);
+            ds.Add<string>(fo.DicomTag.StudyDescription, (string)null);
+            ds.Add<string>( fo.DicomTag.SeriesInstanceUID, (string)null);
+            ds.Add<string>( fo.DicomTag.SeriesNumber, (string)null);
+            ds.Add<string>( fo.DicomTag.Modality, (string)null);
+            ds.Add<string>( fo.DicomTag.SOPInstanceUID, (string)null);
+            ds.Add<string>( fo.DicomTag.SOPClassUID, (string)null);
+            ds.Add<string>( fo.DicomTag.InstanceNumber, (string)null);
 
-            ds.Add<object>(fo.DicomTag.NumberOfFrames, (object)null);
-            ds.Add<object>(fo.DicomTag.BitsAllocated,(object) null);
-            ds.Add<object>(fo.DicomTag.Rows,(object) null);
-            ds.Add<object>(fo.DicomTag.Columns,(object) null);
+            ds.Add<int>(fo.DicomTag.NumberOfFrames);
+            ds.Add<ushort>(fo.DicomTag.BitsAllocated);
+            ds.Add<ushort>(fo.DicomTag.Rows);
+            ds.Add<ushort>(fo.DicomTag.Columns);
 
             return ds ;
         }

--- a/UnitTests/DICOMcloud.Dicom.UnitTest/Helpers/DicomHelpers.cs
+++ b/UnitTests/DICOMcloud.Dicom.UnitTest/Helpers/DicomHelpers.cs
@@ -145,24 +145,24 @@ namespace DICOMcloud.UnitTest
             var ds = new fo.DicomDataset ( ) ;
 
 
-            ds.Add<object> ( fo.DicomTag.PatientID, null) ;
-            ds.Add<object>( fo.DicomTag.PatientName, null);
-            ds.Add<object>( fo.DicomTag.StudyInstanceUID, null);
-            ds.Add<object>( fo.DicomTag.StudyID, null);
-            ds.Add<object>(fo.DicomTag.StudyDate, null);
-            ds.Add<object>( fo.DicomTag.AccessionNumber, null);
-            ds.Add<object>(fo.DicomTag.StudyDescription, null);
-            ds.Add<object>( fo.DicomTag.SeriesInstanceUID, null);
-            ds.Add<object>( fo.DicomTag.SeriesNumber, null);
-            ds.Add<object>( fo.DicomTag.Modality, null);
-            ds.Add<object>( fo.DicomTag.SOPInstanceUID, null);
-            ds.Add<object>( fo.DicomTag.SOPClassUID, null);
-            ds.Add<object>( fo.DicomTag.InstanceNumber, null);
+            ds.Add<object> ( fo.DicomTag.PatientID,(object) null) ;
+            ds.Add<object>( fo.DicomTag.PatientName, (object)null);
+            ds.Add<object>( fo.DicomTag.StudyInstanceUID, (object)null);
+            ds.Add<object>( fo.DicomTag.StudyID, (object)null);
+            ds.Add<object>(fo.DicomTag.StudyDate, (object)null);
+            ds.Add<object>( fo.DicomTag.AccessionNumber, (object)null);
+            ds.Add<object>(fo.DicomTag.StudyDescription, (object)null);
+            ds.Add<object>( fo.DicomTag.SeriesInstanceUID, (object)null);
+            ds.Add<object>( fo.DicomTag.SeriesNumber, (object)null);
+            ds.Add<object>( fo.DicomTag.Modality, (object)null);
+            ds.Add<object>( fo.DicomTag.SOPInstanceUID, (object)null);
+            ds.Add<object>( fo.DicomTag.SOPClassUID, (object)null);
+            ds.Add<object>( fo.DicomTag.InstanceNumber, (object)null);
 
-            ds.Add<object>(fo.DicomTag.NumberOfFrames, null);
-            ds.Add<object>(fo.DicomTag.BitsAllocated, null);
-            ds.Add<object>(fo.DicomTag.Rows, null);
-            ds.Add<object>(fo.DicomTag.Columns, null);
+            ds.Add<object>(fo.DicomTag.NumberOfFrames, (object)null);
+            ds.Add<object>(fo.DicomTag.BitsAllocated,(object) null);
+            ds.Add<object>(fo.DicomTag.Rows,(object) null);
+            ds.Add<object>(fo.DicomTag.Columns,(object) null);
 
             return ds ;
         }

--- a/UnitTests/DICOMcloud.Dicom.UnitTest/ObjectStoreServiceTests.cs
+++ b/UnitTests/DICOMcloud.Dicom.UnitTest/ObjectStoreServiceTests.cs
@@ -75,15 +75,15 @@ namespace DICOMcloud.UnitTest
         
             foreach ( var ds in results)
             { 
-                var sopUid = ds.Get<string> (DicomTag.SOPInstanceUID);
+                var sopUid = ds.GetSingleValue<string> (DicomTag.SOPInstanceUID);
 
-                var stored = storedDs.Where ( n=> n.Get<string> (DicomTag.SOPInstanceUID) == sopUid).FirstOrDefault ( );
+                var stored = storedDs.FirstOrDefault (n => n.GetSingleValue<string> (DicomTag.SOPInstanceUID) == sopUid);
             
                 Assert.IsNotNull (stored);
 
                 foreach ( var element in stored)
                 { 
-                    Assert.AreEqual ( stored.Get<string> (element.Tag), ds.Get<string> (element.Tag));
+                    Assert.AreEqual ( stored.GetSingleValue<string> (element.Tag), ds.GetSingleValue<string> (element.Tag));
                 }
             }
         }

--- a/UnitTests/DICOMcloud.Dicom.UnitTest/ObjectStoreServiceTests.cs
+++ b/UnitTests/DICOMcloud.Dicom.UnitTest/ObjectStoreServiceTests.cs
@@ -114,9 +114,9 @@ namespace DICOMcloud.UnitTest
                 //location include the UIDs, so make sure your storage
                 // folder is close to the root when keeping the original UIDs
                 dataset.AddOrUpdate ( fo.DicomTag.PatientID, "Patient_" + counter ) ;
-                dataset.AddOrUpdate ( fo.DicomTag.StudyInstanceUID, "Study_" + counter ) ;
-                dataset.AddOrUpdate ( fo.DicomTag.SeriesInstanceUID, "Series_" + counter ) ;
-                dataset.AddOrUpdate ( fo.DicomTag.SOPInstanceUID, "Instance_" + counter ) ;
+                dataset.AddOrUpdate ( fo.DicomTag.StudyInstanceUID, "1112." + counter ) ;
+                dataset.AddOrUpdate ( fo.DicomTag.SeriesInstanceUID, "1113." + counter ) ;
+                dataset.AddOrUpdate ( fo.DicomTag.SOPInstanceUID, "1114." + counter ) ;
                 
                 StoreService.StoreDicom ( dataset, new DataAccess.InstanceMetadata ( ) ) ;
 

--- a/UnitTests/DICOMcloud.Dicom.UnitTest/PaginationSearchTest.cs
+++ b/UnitTests/DICOMcloud.Dicom.UnitTest/PaginationSearchTest.cs
@@ -147,7 +147,7 @@ namespace DICOMcloud.UnitTest
                 
                 templateDS.CopyTo ( studyDs );
 
-                studyDs.AddOrUpdate (DicomTag.StudyInstanceUID, string.Format ("std.{0}", studyIndex));
+                studyDs.AddOrUpdate (DicomTag.StudyInstanceUID, string.Format ("999.{0}", studyIndex));
 
                 for (int seriesIndex = 0; seriesIndex  < NumberOfSeriesInStudy; seriesIndex++)
                 {
@@ -156,7 +156,7 @@ namespace DICOMcloud.UnitTest
 
                     studyDs.CopyTo (seriesDs);
 
-                    seriesDs.AddOrUpdate (DicomTag.SeriesInstanceUID, string.Format ("std.{0}.ser.{1}", studyIndex, seriesIndex));
+                    seriesDs.AddOrUpdate (DicomTag.SeriesInstanceUID, string.Format ("333.{0}.444.{1}", studyIndex, seriesIndex));
                     seriesDs.AddOrUpdate(DicomTag.Modality, modalities[studyIndex% modalities.Length]);
                     
                     for (int instanceIndex = 0; instanceIndex < NumberOfInstancesInSeries; instanceIndex++ )
@@ -166,7 +166,7 @@ namespace DICOMcloud.UnitTest
 
                         seriesDs.CopyTo (instanceDs);
 
-                        instanceDs.AddOrUpdate (DicomTag.SOPInstanceUID, string.Format ("std.{0}.ser.{1}.inst.{2}", studyIndex, seriesIndex, instanceIndex));
+                        instanceDs.AddOrUpdate (DicomTag.SOPInstanceUID, string.Format ("333.{0}.444.{1}.555.{2}", studyIndex, seriesIndex, instanceIndex));
 
                         StoreService.StoreDicom(instanceDs, new DataAccess.InstanceMetadata());
                     }

--- a/UnitTests/DICOMcloud.Dicom.UnitTest/packages.config
+++ b/UnitTests/DICOMcloud.Dicom.UnitTest/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="fo-dicom.Desktop" version="3.0.2" targetFramework="net452" />
+  <package id="fo-dicom.Desktop" version="4.0.2" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Most of the update is straightforward.  Many of the unit tests needed to be updated as the latest fo-dicom is stricter in its validation (a good thing!).    The changes fix all warning messages related to obsolete code.  This addresses the upgrade issue #33 