### PR TITLE
[STOW] Fix the issue when StatusMessage exceeds the max length of ReasonPhrase

### DIFF
--- a/DICOMcloud.Wado/Services/WebObjectStoreService.cs
+++ b/DICOMcloud.Wado/Services/WebObjectStoreService.cs
@@ -44,7 +44,10 @@ namespace DICOMcloud.Wado
                 
                 if (!string.IsNullOrWhiteSpace(storeResult.StatusMessage))
                 {
-                    result.ReasonPhrase = storeResult.StatusMessage;
+                    result.ReasonPhrase =
+                        storeResult.StatusMessage.Length > 512 ?
+                        storeResult.StatusMessage.Substring(0, 512) :
+                        storeResult.StatusMessage;
                 }
 
                 result.Content = CreateResponseContent (request, storeResult);


### PR DESCRIPTION
Fix #121 
When there are too many duplicated DICOM files in the POST, DICOMcloud will write exceptions repeatedly in `storeResult.StatusMessage`, such as:
```
SOP Instance already exists;SOP Instance already exists;SOP Instance already exists;SOP Instance already exists;SOP Instance already exists;SOP Instance already exists;SOP Instance already exists;SOP Instance already exists;SOP Instance already exists;...(and more)...
```
Which will exceed the max length (512) of `HttpResponseMessage.ReasonPhrase`